### PR TITLE
Kahan accumulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,12 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fsanitize=address")
 
+option(SLAPH_KAHAN "Use Kahan summation in the accumulation steps" OFF)
+
+if(SLAPH_KAHAN)
+  add_definitions("-DSLAPH_KAHAN")
+endif()
+
 ###############################################################################
 #                                 Executables                                 #
 ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,9 @@ option(SLAPH_KAHAN "Use Kahan summation in the accumulation steps" OFF)
 
 if(SLAPH_KAHAN)
   add_definitions("-DSLAPH_KAHAN")
+  message(STATUS "Using Kahan accumulation with double precision internally")
+else()
+  message(STATUS "Using native double precision accumulation")
 endif()
 
 ###############################################################################

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -3,6 +3,10 @@ find_package(benchmark)
 if(${benchmark_FOUND})
   add_executable(bench-main
     main.cpp
+
+    accumulation.cpp
+    create_momenta.cpp
+
     )
 
   target_link_libraries(bench-main benchmark::benchmark lcontract)

--- a/benchmarks/accumulation.cpp
+++ b/benchmarks/accumulation.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 static std::vector<double> make_numbers() {
-  std::vector<double> numbers(50);
+  std::vector<double> numbers(500);
 
   std::default_random_engine engine(0);
   std::uniform_real_distribution<double> dist(0, 1);

--- a/benchmarks/accumulation.cpp
+++ b/benchmarks/accumulation.cpp
@@ -1,0 +1,50 @@
+#include "KahanAccumulator.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <random>
+#include <vector>
+
+static std::vector<double> make_numbers() {
+  std::vector<double> numbers(50);
+
+  std::default_random_engine engine(0);
+  std::uniform_real_distribution<double> dist(0, 1);
+
+  for (auto &number : numbers) {
+    number = dist(engine);
+  }
+
+  return numbers;
+}
+
+template<typename TestAccumulator>
+static void bm_accumulate(benchmark::State &state) {
+  auto const &numbers = make_numbers();
+
+  for (auto _ : state) {
+    TestAccumulator acc;
+    for (auto const number : numbers) {
+      acc += number;
+    }
+    volatile double value = acc.value();
+  }
+}
+
+static void BM_kahan_double(benchmark::State &state) {
+  bm_accumulate<KahanAccumulator<double>>(state);
+}
+
+BENCHMARK(BM_kahan_double);
+
+static void BM_native_double(benchmark::State &state) {
+  bm_accumulate<NativeAccumulator<double>>(state);
+}
+
+BENCHMARK(BM_native_double);
+
+static void BM_native_quad(benchmark::State &state) {
+  bm_accumulate<NativeAccumulator<long double>>(state);
+}
+
+BENCHMARK(BM_native_quad);

--- a/benchmarks/accumulation.cpp
+++ b/benchmarks/accumulation.cpp
@@ -35,16 +35,16 @@ static void BM_kahan_double(benchmark::State &state) {
   bm_accumulate<KahanAccumulator<double>>(state);
 }
 
-BENCHMARK(BM_kahan_double);
 
 static void BM_native_double(benchmark::State &state) {
   bm_accumulate<NativeAccumulator<double>>(state);
 }
 
-BENCHMARK(BM_native_double);
 
 static void BM_native_quad(benchmark::State &state) {
   bm_accumulate<NativeAccumulator<long double>>(state);
 }
 
 BENCHMARK(BM_native_quad);
+BENCHMARK(BM_native_double);
+BENCHMARK(BM_kahan_double);

--- a/benchmarks/accumulation.cpp
+++ b/benchmarks/accumulation.cpp
@@ -35,11 +35,13 @@ static void BM_kahan_double(benchmark::State &state) {
   bm_accumulate<KahanAccumulator<double>>(state);
 }
 
-
 static void BM_native_double(benchmark::State &state) {
   bm_accumulate<NativeAccumulator<double>>(state);
 }
 
+static void BM_native_float128(benchmark::State &state) {
+  bm_accumulate<NativeAccumulator<__float128>>(state);
+}
 
 static void BM_native_quad(benchmark::State &state) {
   bm_accumulate<NativeAccumulator<long double>>(state);
@@ -47,4 +49,5 @@ static void BM_native_quad(benchmark::State &state) {
 
 BENCHMARK(BM_native_quad);
 BENCHMARK(BM_native_double);
+BENCHMARK(BM_native_float128);
 BENCHMARK(BM_kahan_double);

--- a/benchmarks/create_momenta.cpp
+++ b/benchmarks/create_momenta.cpp
@@ -1,0 +1,27 @@
+#include "OperatorsForMesons.hpp"
+
+#include <benchmark/benchmark.h>
+
+static void BM_create_momenta_old(benchmark::State &state) {
+  ssize_t const Lx = 32, Ly = 32, Lz = 32;
+  std::vector<VdaggerVQuantumNumbers> vdaggerv_lookup{{0, {1, 2, 3}, {}}};
+  array_cd_d2 momentum(boost::extents[1][Lx*Ly*Lz]);
+
+  for (auto _ : state) {
+    create_momenta(Lx, Ly, Lz, vdaggerv_lookup, momentum);
+  }
+}
+
+BENCHMARK(BM_create_momenta_old);
+
+static void BM_create_momenta_new(benchmark::State &state) {
+  ssize_t const Lx = 32, Ly = 32, Lz = 32;
+  std::vector<VdaggerVQuantumNumbers> vdaggerv_lookup{{0, {1, 2, 3}, {}}};
+  array_cd_d2 momentum(boost::extents[1][Lx*Ly*Lz]);
+
+  for (auto _ : state) {
+    create_momenta_new(Lx, Ly, Lz, vdaggerv_lookup, momentum);
+  }
+}
+
+BENCHMARK(BM_create_momenta_new);

--- a/benchmarks/main.cpp
+++ b/benchmarks/main.cpp
@@ -1,29 +1,3 @@
-#include "OperatorsForMesons.hpp"
-
 #include <benchmark/benchmark.h>
-
-static void BM_create_momenta_old(benchmark::State &state) {
-  ssize_t const Lx = 32, Ly = 32, Lz = 32;
-  std::vector<VdaggerVQuantumNumbers> vdaggerv_lookup{{0, {1, 2, 3}, {}}};
-  array_cd_d2 momentum(boost::extents[1][Lx*Ly*Lz]);
-
-  for (auto _ : state) {
-    create_momenta(Lx, Ly, Lz, vdaggerv_lookup, momentum);
-  }
-}
-
-BENCHMARK(BM_create_momenta_old);
-
-static void BM_create_momenta_new(benchmark::State &state) {
-  ssize_t const Lx = 32, Ly = 32, Lz = 32;
-  std::vector<VdaggerVQuantumNumbers> vdaggerv_lookup{{0, {1, 2, 3}, {}}};
-  array_cd_d2 momentum(boost::extents[1][Lx*Ly*Lz]);
-
-  for (auto _ : state) {
-    create_momenta_new(Lx, Ly, Lz, vdaggerv_lookup, momentum);
-  }
-}
-
-BENCHMARK(BM_create_momenta_new);
 
 BENCHMARK_MAIN();

--- a/include/Diagram.hpp
+++ b/include/Diagram.hpp
@@ -127,41 +127,9 @@ class Diagram {
     return correlator_requests_;
   }
 
-  void assemble(int const t, BlockIterator const &slice_pair, DiagramParts &q) {
-    int const tid = omp_get_thread_num();
+  void assemble(int const t, BlockIterator const &slice_pair, DiagramParts &q);
 
-    for (int i = 0; i != ssize(correlator_requests()); ++i) {
-      c_[tid][i] = Complex{};
-    }
-
-    assemble_impl(c_.at(tid), slice_pair, q);
-
-    {
-      std::lock_guard<std::mutex> lock(mutexes_[t]);
-
-      for (int i = 0; i != ssize(correlator_requests()); ++i) {
-        correlator_[t][i] += c_[tid][i];
-      }
-    }
-  }
-
-  void write() {
-    assert(output_path_ != "");
-    assert(output_filename_ != "");
-
-    WriteHDF5Correlator filehandle(
-        output_path_, name(), output_filename_, make_comp_type<Complex>());
-
-    std::vector<Complex> one_corr(Lt_);
-
-    for (int i = 0; i != ssize(correlator_requests()); ++i) {
-      for (int t = 0; t < Lt_; ++t) {
-        one_corr[t] = correlator_[t][i] / static_cast<double>(Lt_);
-      }
-      // Write data to file.
-      filehandle.write(one_corr, correlator_requests()[i].hdf5_dataset_name);
-    }
-  }
+  void write();
 
   std::string const &name() const { return name_; }
 
@@ -171,6 +139,7 @@ class Diagram {
 
   std::vector<CorrelatorRequest> const &correlator_requests_;
 
+ private:
   std::string const &output_path_;
   std::string const &output_filename_;
 

--- a/include/Diagram.hpp
+++ b/include/Diagram.hpp
@@ -124,7 +124,10 @@ class Diagram {
         c_(omp_get_max_threads(),
            AccumulatorVector(correlator_requests.size(), Accumulator<Complex>{})),
         mutexes_(Lt),
-        name_(name) {}
+        name_(name) {
+    assert(output_path_ != "");
+    assert(output_filename_ != "");
+  }
 
   std::vector<CorrelatorRequest> const &correlator_requests() const {
     return correlator_requests_;

--- a/include/Diagram.hpp
+++ b/include/Diagram.hpp
@@ -108,6 +108,8 @@ struct DiagramParts {
 
 class Diagram {
  public:
+  using AccumulatorVector = std::vector<Accumulator<Complex>>;
+
   Diagram(std::vector<CorrelatorRequest> const &correlator_requests,
           std::string const &output_path,
           std::string const &output_filename,
@@ -117,9 +119,10 @@ class Diagram {
         output_path_(output_path),
         output_filename_(output_filename),
         Lt_(Lt),
-        correlator_(Lt, std::vector<Complex>(correlator_requests.size(), Complex{})),
+        correlator_(
+            Lt, AccumulatorVector(correlator_requests.size(), Accumulator<Complex>{})),
         c_(omp_get_max_threads(),
-           std::vector<Complex>(correlator_requests.size(), Complex{})),
+           AccumulatorVector(correlator_requests.size(), Accumulator<Complex>{})),
         mutexes_(Lt),
         name_(name) {}
 
@@ -133,7 +136,7 @@ class Diagram {
 
   std::string const &name() const { return name_; }
 
-  void assemble_impl(std::vector<Complex> &c,
+  void assemble_impl(AccumulatorVector &c,
                      BlockIterator const &slice_pair,
                      DiagramParts &q);
 
@@ -146,10 +149,10 @@ class Diagram {
   int const Lt_;
 
   /** OpenMP-shared correlators, indices are (1) time and (2) correlator id. */
-  std::vector<std::vector<Complex>> correlator_;
+  std::vector<AccumulatorVector> correlator_;
 
   /** OpenMP-shared correlators, indices are (1) thread id and (2) correlator id. */
-  std::vector<std::vector<Complex>> c_;
+  std::vector<AccumulatorVector> c_;
 
   std::vector<std::mutex> mutexes_;
 

--- a/include/DilutedTrace.hpp
+++ b/include/DilutedTrace.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "typedefs.hpp"
-
 #include "DilutedFactor.hpp"
+#include "KahanAccumulator.hpp"
+#include "typedefs.hpp"
 
 struct DilutedTrace {
   using Data = Complex;
@@ -21,6 +21,16 @@ inline Complex operator+(DilutedTrace const &df, Complex const &c) {
 }
 
 inline Complex operator+(Complex const &c, DilutedTrace const &df) {
+  return df + c;
+}
+
+inline Accumulator<Complex> operator+(DilutedTrace const &df,
+                                      Accumulator<Complex> const &c) {
+  return c + df.data;
+}
+
+inline Accumulator<Complex> operator+(Accumulator<Complex> const &c,
+                                      DilutedTrace const &df) {
   return df + c;
 }
 

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -14,7 +14,7 @@
 template <typename Numeric>
 class KahanAccumulator {
  public:
-  Numeric value() const { return sum_ + c_; }
+  Numeric value() const { return sum_ - c_; }
 
   KahanAccumulator &operator+=(Numeric right) {
     if (std::abs(right) > std::abs(sum_)) {

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -41,3 +41,10 @@ class NativeAccumulator {
  private:
   Numeric sum_ = 0.0;
 };
+
+template <typename Numeric>
+#ifdef SLAPH_KAHAN
+using Accumulator = KahanAccumulator<Numeric>;
+#else
+using Accumulator = NativeAccumulator<Numeric>;
+#endif

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -27,6 +27,12 @@ class KahanAccumulator {
     return left += right;
   }
 
+  KahanAccumulator operator+=(KahanAccumulator const right) {
+    sum_ += right.sum_;
+    c_ += right.c_;
+    return *this;
+  }
+
  private:
   Numeric sum_ = 0.0;
   Numeric c_ = 0.0;
@@ -45,6 +51,11 @@ class NativeAccumulator {
   NativeAccumulator operator+(Numeric const right) const {
     NativeAccumulator left = *this;
     return left += right;
+  }
+
+  NativeAccumulator operator+=(NativeAccumulator const right) {
+    sum_ += right.sum_;
+    return *this;
   }
 
  private:

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+/**
+ * Kahan summation implementation.
+ *
+ * The algorithm is taken from
+ * https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+ */
+class KahanAccumulator {
+ public:
+  double value() const { return sum_; }
+
+  KahanAccumulator &operator+=(double const right) {
+    double const y = right - c_;
+    double const t = sum_ + y;
+    c_ = (t - sum_) - y;
+    sum_ = t;
+
+    return *this;
+  }
+
+ private:
+  double sum_ = 0.0;
+  double c_ = 0.0;
+};

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -27,3 +27,17 @@ class KahanAccumulator {
   Numeric sum_ = 0.0;
   Numeric c_ = 0.0;
 };
+
+template <typename Numeric>
+class NativeAccumulator {
+ public:
+  Numeric value() const { return sum_; }
+
+  NativeAccumulator &operator+=(Numeric const right) {
+    sum_ += right;
+    return *this;
+  }
+
+ private:
+  Numeric sum_ = 0.0;
+};

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -14,18 +14,15 @@
 template <typename Numeric>
 class KahanAccumulator {
  public:
-  Numeric value() const { return sum_ - c_; }
+  Numeric value() const { return sum_ + c_; }
 
   KahanAccumulator &operator+=(Numeric right) {
-    if (std::abs(right) > std::abs(sum_)) {
-      auto const temp = sum_;
-      sum_ = right;
-      right = temp;
+    Numeric const t = sum_ + right;
+    if (std::abs(sum_) >= std::abs(right)) {
+      c_ += (sum_ - t) + right;
+    } else {
+      c_ += (right - t) + sum_;
     }
-
-    Numeric const y = right - c_;
-    Numeric const t = sum_ + y;
-    c_ = (t - sum_) - y;
     sum_ = t;
     return *this;
   }
@@ -40,9 +37,6 @@ class KahanAccumulator {
     c_ += right.c_;
     return *this;
   }
-
-  Numeric sum() { return sum_; }
-  Numeric c() { return c_; }
 
  private:
   Numeric sum_ = 0.0;

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -12,7 +12,7 @@
 template <typename Numeric>
 class KahanAccumulator {
  public:
-  Numeric value() const { return sum_; }
+  Numeric value() const { return sum_ + c_; }
 
   KahanAccumulator &operator+=(Numeric const right) {
     Numeric const y = right - c_;

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -41,6 +41,9 @@ class KahanAccumulator {
     return *this;
   }
 
+  Numeric sum() { return sum_; }
+  Numeric c() { return c_; }
+
  private:
   Numeric sum_ = 0.0;
   Numeric c_ = 0.0;

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -19,8 +19,12 @@ class KahanAccumulator {
     Numeric const t = sum_ + y;
     c_ = (t - sum_) - y;
     sum_ = t;
-
     return *this;
+  }
+
+  KahanAccumulator operator+(Numeric const right) const {
+    KahanAccumulator left = *this;
+    return left += right;
   }
 
  private:
@@ -33,9 +37,14 @@ class NativeAccumulator {
  public:
   Numeric value() const { return sum_; }
 
-  NativeAccumulator &operator+=(Numeric const right) {
+  NativeAccumulator operator+=(Numeric const right) {
     sum_ += right;
     return *this;
+  }
+
+  NativeAccumulator operator+(Numeric const right) const {
+    NativeAccumulator left = *this;
+    return left += right;
   }
 
  private:

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -5,14 +5,18 @@
  *
  * The algorithm is taken from
  * https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+ *
+ * @tparam Numeric A numeric type which supports addition and subtraction. The
+ * most sensible values are `double` and `std::complex<double>`.
  */
+template <typename Numeric>
 class KahanAccumulator {
  public:
-  double value() const { return sum_; }
+  Numeric value() const { return sum_; }
 
-  KahanAccumulator &operator+=(double const right) {
-    double const y = right - c_;
-    double const t = sum_ + y;
+  KahanAccumulator &operator+=(Numeric const right) {
+    Numeric const y = right - c_;
+    Numeric const t = sum_ + y;
     c_ = (t - sum_) - y;
     sum_ = t;
 
@@ -20,6 +24,6 @@ class KahanAccumulator {
   }
 
  private:
-  double sum_ = 0.0;
-  double c_ = 0.0;
+  Numeric sum_ = 0.0;
+  Numeric c_ = 0.0;
 };

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cmath>
+
 /**
  * Kahan summation implementation.
  *
@@ -14,7 +16,13 @@ class KahanAccumulator {
  public:
   Numeric value() const { return sum_ + c_; }
 
-  KahanAccumulator &operator+=(Numeric const right) {
+  KahanAccumulator &operator+=(Numeric right) {
+    if (std::abs(right) > std::abs(sum_)) {
+      auto const temp = sum_;
+      sum_ = right;
+      right = temp;
+    }
+
     Numeric const y = right - c_;
     Numeric const t = sum_ + y;
     c_ = (t - sum_) - y;

--- a/include/KahanAccumulator.hpp
+++ b/include/KahanAccumulator.hpp
@@ -16,6 +16,10 @@ class KahanAccumulator {
  public:
   Numeric value() const { return sum_ + c_; }
 
+  /**
+   * Algorithm taken from
+   * https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements.
+   */
   KahanAccumulator &operator+=(Numeric right) {
     Numeric const t = sum_ + right;
     if (std::abs(sum_) >= std::abs(right)) {

--- a/src/Diagram.cpp
+++ b/src/Diagram.cpp
@@ -120,9 +120,6 @@ void Diagram::assemble_impl(AccumulatorVector &c,
 }
 
 void Diagram::write() {
-  assert(output_path_ != "");
-  assert(output_filename_ != "");
-
   WriteHDF5Correlator filehandle(
       output_path_, name(), output_filename_, make_comp_type<Complex>());
 

--- a/src/Diagram.cpp
+++ b/src/Diagram.cpp
@@ -1,5 +1,6 @@
 #include "Diagram.hpp"
 
+#include "KahanAccumulator.hpp"
 #include "local_timer.hpp"
 
 #include <omp.h>
@@ -19,7 +20,7 @@ Complex resolve_request1(std::vector<TraceRequest> const &trace_requests,
                        ->get(slice_pair, locations0)
                        .at(trace_request0.tr_id);
 
-  return std::accumulate(std::begin(x0), std::end(x0), Complex{0.0, 0.0}) /
+  return std::accumulate(std::begin(x0), std::end(x0), Accumulator<Complex>{}).value() /
          static_cast<double>(x0.size());
 }
 

--- a/src/Diagram.cpp
+++ b/src/Diagram.cpp
@@ -91,7 +91,7 @@ void Diagram::assemble(int const t, BlockIterator const &slice_pair, DiagramPart
   int const tid = omp_get_thread_num();
 
   for (int i = 0; i != ssize(correlator_requests()); ++i) {
-    c_[tid][i] = Complex{};
+    c_[tid][i] = Accumulator<Complex>{};
   }
 
   assemble_impl(c_.at(tid), slice_pair, q);
@@ -105,7 +105,7 @@ void Diagram::assemble(int const t, BlockIterator const &slice_pair, DiagramPart
   }
 }
 
-void Diagram::assemble_impl(std::vector<Complex> &c,
+void Diagram::assemble_impl(AccumulatorVector &c,
                             BlockIterator const &slice_pair,
                             DiagramParts &q) {
   assert(correlator_requests().size() == correlator_requests().size());
@@ -130,7 +130,7 @@ void Diagram::write() {
 
   for (int i = 0; i != ssize(correlator_requests()); ++i) {
     for (int t = 0; t < Lt_; ++t) {
-      one_corr[t] = correlator_[t][i] / static_cast<double>(Lt_);
+      one_corr[t] = correlator_[t][i].value() / static_cast<double>(Lt_);
     }
     // Write data to file.
     filehandle.write(one_corr, correlator_requests()[i].hdf5_dataset_name);

--- a/src/DilutedFactor.cpp
+++ b/src/DilutedFactor.cpp
@@ -67,6 +67,10 @@ Complex trace(std::vector<DilutedFactor> const &left_vec,
     auto const inner_rnd_id = left.ric.second;
 
     LT_ULTRA_FINE_START;
+
+    // XXX (MU 2019-01-03): This variable is an accumulator, but it runs with
+    // double precision in all cases. The discussion has been started at
+    // https://github.com/HISKP-LQCD/sLapH-contractions/pull/87#issuecomment-451157721.
     Eigen::MatrixXcd right_sum(
         Eigen::MatrixXcd::Zero(left.data.rows(), left.data.cols()));
 

--- a/src/DilutedFactor.cpp
+++ b/src/DilutedFactor.cpp
@@ -1,5 +1,7 @@
 #include "DilutedFactor.hpp"
 
+#include "KahanAccumulator.hpp"
+
 std::vector<DilutedFactor> operator*(std::vector<DilutedFactor> const &left_vec,
                                      std::vector<DilutedFactor> const &right_vec) {
   assert(left_vec.size() > 0);
@@ -57,7 +59,7 @@ Complex trace(std::vector<DilutedFactor> const &left_vec,
   assert(right_vec.size() > 0);
 
   int num_summands = 0;
-  Complex result(0.0, 0.0);
+  Accumulator<Complex> result;
   LT_ULTRA_FINE_DECLARE;
 
   for (auto const &left : left_vec) {
@@ -111,5 +113,5 @@ Complex trace(std::vector<DilutedFactor> const &left_vec,
         "summands.");
   }
 
-  return result / static_cast<double>(num_summands);
+  return result.value() / static_cast<double>(num_summands);
 }

--- a/src/DilutedTrace.cpp
+++ b/src/DilutedTrace.cpp
@@ -5,12 +5,12 @@ Complex inner_product(DilutedTraces const &left_vec, DilutedTraces const &right_
   assert(right_vec.traces.size() > 0);
 
   int num_summands = 0;
-  Complex result{0.0, 0.0};
+  Accumulator<Complex> result;
   LT_ULTRA_FINE_DECLARE;
 
   LT_ULTRA_FINE_START;
   for (auto const &left : left_vec.traces) {
-    Complex right_sum(0.0, 0.0);
+    Accumulator<Complex> right_sum;
 
     for (auto const &right : right_vec.traces) {
       // We also need to be careful to not combine factors which have common used random
@@ -29,7 +29,7 @@ Complex inner_product(DilutedTraces const &left_vec, DilutedTraces const &right_
       ++num_summands;
     }
 
-    result += left.data * right_sum;
+    result += left.data * right_sum.value();
   }
   LT_ULTRA_FINE_STOP;
   LT_ULTRA_FINE_PRINT("[Complex inner_product(DilutedTraces, DilutedTraces]");
@@ -40,7 +40,7 @@ Complex inner_product(DilutedTraces const &left_vec, DilutedTraces const &right_
         "vector<DilutedTrace>) has an empty result. Not enough random vectors?");
   }
 
-  return result / static_cast<double>(num_summands);
+  return result.value() / static_cast<double>(num_summands);
 }
 
 Complex inner_product(DilutedTraces const &left_vec,
@@ -51,13 +51,13 @@ Complex inner_product(DilutedTraces const &left_vec,
   assert(right_vec.traces.size() > 0);
 
   int num_summands = 0;
-  Complex result{0.0, 0.0};
+  Accumulator<Complex> result;
   LT_ULTRA_FINE_DECLARE;
 
   LT_ULTRA_FINE_START;
   for (auto const &left : left_vec.traces) {
     for (auto const &middle : middle_vec.traces) {
-      Complex right_sum(0.0, 0.0);
+      Accumulator<Complex> right_sum;
 
       for (auto const &right : right_vec.traces) {
         if ((left.used_rnd_ids & middle.used_rnd_ids & right.used_rnd_ids) != 0u) {
@@ -68,7 +68,7 @@ Complex inner_product(DilutedTraces const &left_vec,
         ++num_summands;
       }
 
-      result += left.data * middle.data * right_sum;
+      result += left.data * middle.data * right_sum.value();
     }
   }
   LT_ULTRA_FINE_STOP;
@@ -81,7 +81,7 @@ Complex inner_product(DilutedTraces const &left_vec,
         "vector<DilutedTrace>) has an empty result. Not enough random vectors?");
   }
 
-  return result / static_cast<double>(num_summands);
+  return result.value() / static_cast<double>(num_summands);
 }
 
 std::vector<DilutedTrace> factor_to_trace(std::vector<DilutedFactor> const &left_vec,

--- a/src/DilutedTrace.cpp
+++ b/src/DilutedTrace.cpp
@@ -127,8 +127,7 @@ std::vector<DilutedTrace> factor_to_trace(std::vector<DilutedFactor> const &left
       // instances, we do not care to preserve the information about the used random
       // vector indices. Therefore we can sum all these elements up to have less
       // multiplications to do.
-      result_vec.push_back(
-          {typename DilutedTrace::Data{(left.data * right.data).trace()}, used});
+      result_vec.push_back({DilutedTrace::Data{(left.data * right.data).trace()}, used});
     }
     LT_ULTRA_FINE_STOP;
     LT_ULTRA_FINE_PRINT("[DilutedFactor::factor_to_trace] multiply_trace");

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -11,6 +11,7 @@ if(${GTEST_FOUND})
     main.cpp
     gamma.cpp
     create_momenta.cpp
+    KahanAccumulatorTest.cpp
     )
 
   target_link_libraries(main-gtest GTest::GTest lcontract)

--- a/tests/gtest/KahanAccumulatorTest.cpp
+++ b/tests/gtest/KahanAccumulatorTest.cpp
@@ -1,0 +1,46 @@
+#include "KahanAccumulator.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <iostream>
+
+// A simple test where the normal double precision is sufficient.
+TEST(KahanAccumulator, simple) {
+  KahanAccumulator acc;
+  double sum = 0.0;
+
+  for (int i = 1; i != 10; ++i) {
+    acc += i;
+    sum += i;
+  }
+
+  EXPECT_NEAR(acc.value(), sum, 1e-20);
+}
+
+// Add a fraction of the double epsilon to 1.0 many times. With the
+// conventional addition the result will still say 1.0, with the Kahan
+// summation we expect an exact result.
+TEST(KahanAccumulator, hard) {
+  KahanAccumulator acc;
+  double sum = 0.0;
+
+  acc += 1.0;
+  sum += 1.0;
+
+  int const iters = 10000;
+
+  double const eps = std::numeric_limits<double>::epsilon();
+  double const summand = eps / 100;
+  double const exact = 1.0 + iters * summand;
+
+  for (int i = 0; i < iters; ++i) {
+    acc += summand;
+    sum += summand;
+  }
+
+  // One has to be very careful with exact equality on floating point numbers.
+  // In this particular case we do want an exact equality, though.
+  EXPECT_EQ(acc.value(), exact);
+  EXPECT_NE(sum, exact);
+}

--- a/tests/gtest/KahanAccumulatorTest.cpp
+++ b/tests/gtest/KahanAccumulatorTest.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 
 // A simple test where the normal double precision is sufficient.
-TEST(KahanAccumulator, simple) {
+TEST(KahanAccumulator, kahanSimple) {
   KahanAccumulator<double> acc;
   double sum = 0.0;
 
@@ -21,7 +21,7 @@ TEST(KahanAccumulator, simple) {
 // Add a fraction of the double epsilon to 1.0 many times. With the
 // conventional addition the result will still say 1.0, with the Kahan
 // summation we expect an exact result.
-TEST(KahanAccumulator, hard) {
+TEST(KahanAccumulator, kahanHard) {
   KahanAccumulator<double> acc;
   double sum = 0.0;
 

--- a/tests/gtest/KahanAccumulatorTest.cpp
+++ b/tests/gtest/KahanAccumulatorTest.cpp
@@ -7,7 +7,7 @@
 
 // A simple test where the normal double precision is sufficient.
 TEST(KahanAccumulator, simple) {
-  KahanAccumulator acc;
+  KahanAccumulator<double> acc;
   double sum = 0.0;
 
   for (int i = 1; i != 10; ++i) {
@@ -22,7 +22,7 @@ TEST(KahanAccumulator, simple) {
 // conventional addition the result will still say 1.0, with the Kahan
 // summation we expect an exact result.
 TEST(KahanAccumulator, hard) {
-  KahanAccumulator acc;
+  KahanAccumulator<double> acc;
   double sum = 0.0;
 
   acc += 1.0;

--- a/tests/gtest/KahanAccumulatorTest.cpp
+++ b/tests/gtest/KahanAccumulatorTest.cpp
@@ -47,7 +47,7 @@ TEST(KahanAccumulator, kahanHard) {
 
 TEST(KahanAccumulator, kahanPrecision) {
   double const eps = std::numeric_limits<double>::epsilon();
-  double const summand = eps / 4;
+  double const summand = eps * 1e-15;
 
   KahanAccumulator<double> acc;
   acc += 1.0;

--- a/tests/gtest/KahanAccumulatorTest.cpp
+++ b/tests/gtest/KahanAccumulatorTest.cpp
@@ -44,3 +44,33 @@ TEST(KahanAccumulator, kahanHard) {
   EXPECT_EQ(acc.value(), exact);
   EXPECT_NE(sum, exact);
 }
+
+TEST(KahanAccumulator, kahanPrecision) {
+  double const eps = std::numeric_limits<double>::epsilon();
+  double const summand = eps / 4;
+
+  KahanAccumulator<double> acc;
+  std::cout << "| Begin | " << acc.sum() << " | " << acc.c() << " |\n";
+  acc += 1.0;
+  std::cout << "| += 1.0 | " << acc.sum() << " | " << acc.c() << " |\n";
+  acc += summand;
+  std::cout << "| += summand | " << acc.sum() << " | " << acc.c() << " |\n";
+  acc += -1.0;
+  std::cout << "| += -1.0 | " << acc.sum() << " | " << acc.c() << " |\n";
+
+  EXPECT_NE(acc.value(), 0.0);
+  EXPECT_EQ(acc.value(), summand) << "sum: " << acc.sum() << ", c: " << acc.c();
+}
+
+TEST(KahanAccumulator, longDoublePrecision) {
+  double const eps = std::numeric_limits<double>::epsilon();
+  double const summand = eps * 1e-1;
+
+  NativeAccumulator<long double> acc;
+  acc += 1.0;
+  acc += summand;
+  acc += -1.0;
+
+  EXPECT_NE(acc.value(), 0.0);
+  EXPECT_NEAR(acc.value(), summand, eps);
+}

--- a/tests/gtest/KahanAccumulatorTest.cpp
+++ b/tests/gtest/KahanAccumulatorTest.cpp
@@ -50,16 +50,12 @@ TEST(KahanAccumulator, kahanPrecision) {
   double const summand = eps / 4;
 
   KahanAccumulator<double> acc;
-  std::cout << "| Begin | " << acc.sum() << " | " << acc.c() << " |\n";
   acc += 1.0;
-  std::cout << "| += 1.0 | " << acc.sum() << " | " << acc.c() << " |\n";
   acc += summand;
-  std::cout << "| += summand | " << acc.sum() << " | " << acc.c() << " |\n";
   acc += -1.0;
-  std::cout << "| += -1.0 | " << acc.sum() << " | " << acc.c() << " |\n";
 
   EXPECT_NE(acc.value(), 0.0);
-  EXPECT_EQ(acc.value(), summand) << "sum: " << acc.sum() << ", c: " << acc.c();
+  EXPECT_EQ(acc.value(), summand);
 }
 
 TEST(KahanAccumulator, longDoublePrecision) {

--- a/tests/gtest/KahanAccumulatorTest.cpp
+++ b/tests/gtest/KahanAccumulatorTest.cpp
@@ -57,16 +57,3 @@ TEST(KahanAccumulator, kahanPrecision) {
   EXPECT_NE(acc.value(), 0.0);
   EXPECT_EQ(acc.value(), summand);
 }
-
-TEST(KahanAccumulator, longDoublePrecision) {
-  double const eps = std::numeric_limits<double>::epsilon();
-  double const summand = eps * 1e-1;
-
-  NativeAccumulator<long double> acc;
-  acc += 1.0;
-  acc += summand;
-  acc += -1.0;
-
-  EXPECT_NE(acc.value(), 0.0);
-  EXPECT_NEAR(acc.value(), summand, eps);
-}


### PR DESCRIPTION
I have added a `KahanAccumulator` and a `NativeAccumulator` which is just a fancy wrapper for plain accumulation. Using a CMake option one can switch between the two.

There is one issue that I am unsure about: What happens if I add two Kahan accumulators? Is that the right thing to do?

```cpp
  KahanAccumulator operator+=(KahanAccumulator const right) {
    sum_ += right.sum_;
    c_ += right.c_;
    return *this;
  }
```

Not all intermediate results are accumulators. This means that we are sometimes discarding this correction term `c`. Shall we use the accumulators all the way or is it sufficient to have it on the same level only?

Couln't we also just use `long double` and have quad precision much easier?