### PR TITLE
Serialize GlobalData after setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Testing/Temporary
 tests/Testing/Temporary
 sLapH-contractions.creator.user
 make-coffee-build.sh
+tests/integration-L4/global_data.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ target_link_libraries(lcontract PUBLIC ${HDF5_LIBRARIES})
 
 # Boost
 if(NOT DEFINED Boost_INCLUDE_DIRS OR NOT DEFINED Boost_LIBRARIES)
-  find_package(Boost REQUIRED COMPONENTS filesystem system program_options)
+  find_package(Boost REQUIRED COMPONENTS filesystem program_options serialization system)
 endif()
 target_include_directories(lcontract PUBLIC ${Boost_INCLUDE_DIRS})
 target_link_libraries(lcontract PUBLIC ${Boost_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,18 +163,23 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fsanitize=address")
 #                                 Executables                                 #
 ###############################################################################
 
-### contract
+# globaldata
+add_executable(globaldata main/globaldata.cpp)
+target_link_libraries(globaldata lcontract)
 
+install(TARGETS globaldata DESTINATION bin)
+
+# contract
 add_executable(contract main/contract.cpp)
 target_link_libraries(contract lcontract)
 
 install(TARGETS contract DESTINATION bin)
 
-### test-iterator
+# test-iterator
 add_executable(test-dilution-iterator main/test-iterator.cpp)
 target_link_libraries(test-dilution-iterator lcontract)
 
-### test-derivative
+# test-derivative
 add_executable(test-derivative main/test-derivative.cpp)
 target_link_libraries(test-derivative lcontract)
 
@@ -196,11 +201,11 @@ add_test(NAME "integration_L4_all_diagrams"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/tests/integration-L4")
 
 add_test(NAME "integration_L4_charged_diagrams"
-  COMMAND "${CMAKE_CURRENT_BINARY_DIR}/contract" -i test_conjugated.ini --start_config 1000 --end_config 1000
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/integration-L4/run-integration-test-conjugated" "${CMAKE_CURRENT_BINARY_DIR}"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/tests/integration-L4")
 
 add_test(NAME "integration_L4_neutral_diagrams"
-  COMMAND "${CMAKE_CURRENT_BINARY_DIR}/contract" -i test_neutral.ini --start_config 1000 --end_config 1000
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/tests/integration-L4/run-integration-test-neutral" "${CMAKE_CURRENT_BINARY_DIR}"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/tests/integration-L4")
 
 add_test(NAME unit-dilution-iterator

--- a/include/Correlators.hpp
+++ b/include/Correlators.hpp
@@ -7,7 +7,7 @@
 #include "global_data.hpp"
 #include "typedefs.hpp"
 
-#include <string>
+#include <boost/serialization/string.hpp>
 
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/include/DiagramSpec.hpp
+++ b/include/DiagramSpec.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <map>
-#include <string>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/string.hpp>
+#include <boost/serialization/vector.hpp>
+
 #include <utility>
-#include <vector>
 
 struct QuarklineSpec {
   std::string name;

--- a/include/DilutedFactor.hpp
+++ b/include/DilutedFactor.hpp
@@ -8,11 +8,11 @@
 
 #include <omp.h>
 #include <Eigen/Dense>
+#include <boost/serialization/vector.hpp>
 
 #include <iosfwd>
 #include <set>
 #include <sstream>
-#include <vector>
 
 typedef uint16_t UsedRnd;
 

--- a/include/DilutedFactorFactory.hpp
+++ b/include/DilutedFactorFactory.hpp
@@ -10,12 +10,12 @@
 #include <Eigen/Dense>
 #include <boost/circular_buffer.hpp>
 #include <boost/multi_array.hpp>
+#include <boost/serialization/string.hpp>
 
 #include <algorithm>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <string>
 
 template <typename T, ssize_t n>
 void print(std::array<T, n> const &a) {

--- a/include/EigenVector.hpp
+++ b/include/EigenVector.hpp
@@ -4,10 +4,10 @@
 #include "typedefs.hpp"
 
 #include <Eigen/Dense>
+#include <boost/serialization/string.hpp>
 
 #include <fstream>
 #include <iostream>
-#include <string>
 
 class EigenVector {
  private:

--- a/include/Eigen_Boost_serialization.hpp
+++ b/include/Eigen_Boost_serialization.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+namespace boost {
+namespace serialization {
+
+template <class Archive,
+          class S,
+          int Rows_,
+          int Cols_,
+          int Ops_,
+          int MaxRows_,
+          int MaxCols_>
+inline void serialize(Archive &ar,
+                      Eigen::Matrix<S, Rows_, Cols_, Ops_, MaxRows_, MaxCols_> &matrix,
+                      const unsigned int version) {
+  int rows = matrix.rows();
+  int cols = matrix.cols();
+  ar &make_nvp("rows", rows);
+  ar &make_nvp("cols", cols);
+  matrix.resize(rows, cols);  // no-op if size does not change!
+
+  // always save/load row-major
+  for (int r = 0; r < rows; ++r)
+    for (int c = 0; c < cols; ++c)
+      ar &make_nvp("val", matrix(r, c));
+}
+
+template <class Archive, class S, int Dim_, int Mode_, int Options_>
+inline void serialize(Archive &ar,
+                      Eigen::Transform<S, Dim_, Mode_, Options_> &transform,
+                      const unsigned int version) {
+  serialize(ar, transform.matrix(), version);
+}
+}  // namespace serialization
+}  // namespace boost

--- a/include/Gamma.hpp
+++ b/include/Gamma.hpp
@@ -2,8 +2,8 @@
 
 #include "typedefs.hpp"
 
-#include <array>
-#include <vector>
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/vector.hpp>
 
 struct gamma_lookup {
   std::array<int, 4> row;

--- a/include/GaugeField.hpp
+++ b/include/GaugeField.hpp
@@ -6,6 +6,7 @@
 #include "typedefs.hpp"
 
 #include <boost/multi_array.hpp>
+#include <boost/serialization/vector.hpp>
 #include <unsupported/Eigen/MatrixFunctions>
 
 #include <cmath>
@@ -14,7 +15,6 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <vector>
 
 //! \typedef 2dim array for lookup tables
 typedef boost::multi_array<int, 2> look;

--- a/include/OperatorsForMesons.hpp
+++ b/include/OperatorsForMesons.hpp
@@ -10,13 +10,13 @@
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/multi_array.hpp>
+#include <boost/serialization/string.hpp>
 
 #include <Eigen/Dense>
 #include <algorithm>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <string>
 
 /** Calculates operators as they emerge in correlation functions using the
  *  stochastic estimates from the stochastic Laplacian Heaviside method

--- a/include/Perambulator.hpp
+++ b/include/Perambulator.hpp
@@ -4,12 +4,12 @@
 #include "typedefs.hpp"
 
 #include <Eigen/Dense>
+#include <boost/serialization/vector.hpp>
 
 #include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <vector>
 
 /** Memory allocation and reading routines for perambulators */
 class Perambulator {

--- a/include/RandomVector.hpp
+++ b/include/RandomVector.hpp
@@ -2,11 +2,12 @@
 
 #include "typedefs.hpp"
 
+#include <boost/serialization/string.hpp>
+#include <boost/serialization/vector.hpp>
+
 #include <complex>
 #include <fstream>
 #include <iostream>
-#include <string>
-#include <vector>
 
 /** Memory allocation and IO routines for random vectors */
 class RandomVector {

--- a/include/StopWatch.hpp
+++ b/include/StopWatch.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>
+#include <boost/serialization/vector.hpp>
 
 /**
    Usage example:

--- a/include/dilution-iterator.hpp
+++ b/include/dilution-iterator.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <boost/serialization/map.hpp>
+
 #include <cassert>
 #include <iomanip>
 #include <iostream>
-#include <map>
 #include <stdexcept>
 #include <type_traits>
 

--- a/include/global_data.hpp
+++ b/include/global_data.hpp
@@ -3,12 +3,13 @@
 #include "global_data_typedefs.hpp"
 #include "typedefs.hpp"
 
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/string.hpp>
+#include <boost/serialization/vector.hpp>
+
 #include <sys/stat.h>
-#include <array>
 #include <iosfwd>
-#include <map>
-#include <string>
-#include <vector>
 
 typedef std::map<std::string, std::vector<DiagramIndex>> DiagramIndicesCollection;
 typedef std::map<std::string, std::vector<Indices>> TraceIndicesCollection;
@@ -24,6 +25,13 @@ struct TraceRequest {
     return tr_name == other.tr_name && tr_id == other.tr_id &&
            locations == other.locations;
   }
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &tr_name;
+    ar &tr_id;
+    ar &locations;
+  }
 };
 
 struct CorrelatorRequest {
@@ -32,6 +40,12 @@ struct CorrelatorRequest {
 
   bool operator==(CorrelatorRequest const &other) const {
     return trace_requests == other.trace_requests;
+  }
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &trace_requests;
+    ar &hdf5_dataset_name;
   }
 };
 
@@ -97,6 +111,44 @@ struct GlobalData {
   std::map<int, int> momentum_cutoff;
 
   HypPars hyp_parameters;
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &Lx;
+    ar &Ly;
+    ar &Lz;
+    ar &Lt;
+    ar &dim_row;
+    ar &V_TS;
+    ar &V_for_lime;
+    ar &number_of_eigen_vec;
+    ar &number_of_inversions;
+    ar &start_config;
+    ar &end_config;
+    ar &delta_config;
+    ar &verbose;
+    ar &nb_eigen_threads;
+    ar &path_eigenvectors;
+    ar &name_eigenvectors;
+    ar &filename_eigenvectors;
+    ar &path_perambulators;
+    ar &name_perambulators;
+    ar &name_lattice;
+    ar &filename_ending_correlators;
+    ar &path_output;
+    ar &path_config;
+    ar &handling_vdaggerv;
+    ar &path_vdaggerv;
+    ar &rnd_vec_construct;
+    ar &peram_construct;
+    ar &quarks;
+    ar &operator_list;
+    ar &correlator_list;
+    ar &quarkline_lookuptable;
+    ar &operator_lookuptable;
+    ar &trace_indices_map;
+    ar &correlator_requests_map;
+  }
 };
 
 /**

--- a/include/global_data_typedefs.hpp
+++ b/include/global_data_typedefs.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "typedefs.hpp"
-
-#include <Eigen/Dense>
+#include "Eigen_Boost_serialization.hpp"
 
 #include <ostream>
 
@@ -14,6 +13,13 @@
 struct RandomVectorConstruction {
   ssize_t nb_entities, length;
   std::vector<std::string> filename_list;
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &nb_entities;
+    ar &length;
+    ar &filename_list;
+  }
 };
 
 /** Small struct which contains all information to build and read
@@ -26,6 +32,14 @@ struct PerambulatorConstruction {
   std::vector<ssize_t> size_rows;
   std::vector<ssize_t> size_cols;
   std::vector<std::string> filename_list;
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &nb_entities;
+    ar &size_rows;
+    ar &size_cols;
+    ar &filename_list;
+  }
 };
 
 /** Quark type that contains all quark propagator informations:
@@ -69,6 +83,20 @@ struct quark {
         number_of_dilution_D(number_of_dilution_D),
         id(id),
         path(path) {}
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &type;
+    ar &number_of_rnd_vec;
+    ar &dilution_T;
+    ar &number_of_dilution_T;
+    ar &dilution_E;
+    ar &number_of_dilution_E;
+    ar &dilution_D;
+    ar &number_of_dilution_D;
+    ar &id;
+    ar &path;
+  }
 };
 
 /** Struct that contains all physical information specifying a quantum field
@@ -86,6 +114,13 @@ struct QuantumNumbers {
   std::vector<int> gamma;
   DisplacementDirection displacement;
   VectorData momentum;
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &gamma;
+    ar &displacement;
+    ar &momentum;
+  }
 };
 
 inline std::string to_string(std::vector<int> const &vec) {
@@ -147,6 +182,15 @@ struct Correlators_2 {
   std::vector<int> operator_numbers;
   std::string GEVP;
   std::vector<VectorData> tot_mom;
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &type;
+    ar &quark_numbers;
+    ar &operator_numbers;
+    ar &GEVP;
+    ar &tot_mom;
+  }
 };
 
 typedef std::vector<QuantumNumbers> Operators;
@@ -159,4 +203,11 @@ struct HypPars {
   double alpha1;
   double alpha2;
   ssize_t iterations;
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &alpha1;
+    ar &alpha2;
+    ar &iterations;
+  }
 };

--- a/include/global_data_typedefs.hpp
+++ b/include/global_data_typedefs.hpp
@@ -62,6 +62,8 @@ struct quark {
   ssize_t id;
   std::string path;
 
+  quark() {}
+
   /** Constructor */
   quark(std::string type,
         int number_of_rnd_vec,

--- a/include/global_data_utils.hpp
+++ b/include/global_data_utils.hpp
@@ -3,9 +3,10 @@
 #include "global_data_typedefs.hpp"
 #include "typedefs.hpp"
 
-#include <array>
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/string.hpp>
+
 #include <iostream>
-#include <string>
 
 namespace global_data_utils {
 

--- a/include/h5-wrapper.hpp
+++ b/include/h5-wrapper.hpp
@@ -7,11 +7,11 @@
 #include <H5Cpp.h>
 #include <omp.h>
 #include <boost/filesystem.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/string.hpp>
 
 #include <iostream>
-#include <map>
 #include <sstream>
-#include <string>
 
 #define PRINT(x) std::cout << #x << ": " << (x) << std::endl;
 

--- a/include/local_timer.hpp
+++ b/include/local_timer.hpp
@@ -2,8 +2,9 @@
 
 #include <omp.h>
 
+#include <boost/serialization/string.hpp>
+
 #include <iostream>
-#include <string>
 
 static inline void lt_print(const std::string msg, const double &local_timer) {
 #pragma omp critical(cout)

--- a/include/typedefs.hpp
+++ b/include/typedefs.hpp
@@ -47,6 +47,8 @@ struct VdaggerVQuantumNumbers {
   std::array<int, 3> momentum;        /**< The -momentum as 3-vector */
   DisplacementDirection displacement; /**< The displacement as 3-vector */
 
+  VdaggerVQuantumNumbers() {}
+
   VdaggerVQuantumNumbers(const ssize_t id,
                          std::array<int, 3> const &momentum,
                          DisplacementDirection const &displacement)

--- a/include/typedefs.hpp
+++ b/include/typedefs.hpp
@@ -2,12 +2,13 @@
 
 #include "ComplexProduct.hpp"
 
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/list.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/vector.hpp>
+
 #include <algorithm>
-#include <array>
 #include <iomanip>
-#include <list>
-#include <map>
-#include <vector>
 
 int constexpr max_rnd_ids = 10;
 size_t constexpr max_used_rnd_ids = 6;
@@ -50,6 +51,13 @@ struct VdaggerVQuantumNumbers {
                          std::array<int, 3> const &momentum,
                          DisplacementDirection const &displacement)
       : id(id), momentum(momentum), displacement(displacement) {}
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &id;
+    ar &momentum;
+    ar &displacement;
+  }
 };
 
 /** Struct that contains all information for a sLapH operator
@@ -75,6 +83,13 @@ struct OperatorLookup {
   bool need_gaugefield = false;
 
   inline ssize_t size() { return vdaggerv_lookup.size(); }
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &vdaggerv_lookup;
+    ar &index_of_unity;
+    ar &need_gaugefield;
+  }
 };
 
 /** Struct that holds all information on which VdaggerV must be diluted with
@@ -118,6 +133,14 @@ struct DilutedFactorIndex {
    *  specified by @em id_q1 and @em id_q2
    */
   std::vector<std::pair<ssize_t, ssize_t>> rnd_vec_ids;
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &id_vdaggerv;
+    ar &need_vdaggerv_daggering;
+    ar &gamma;
+    ar &rnd_vec_ids;
+  }
 };
 
 inline bool operator==(DilutedFactorIndex const &first, DilutedFactorIndex const second) {
@@ -157,6 +180,14 @@ struct DiagramIndex {
                const std::vector<ssize_t> &lookup,
                const std::vector<int> &gamma = {})
       : id(id), hdf5_dataset_name(hdf5_dataset_name), lookup(lookup), gamma(gamma){};
+
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int version) {
+    ar &id;
+    ar &hdf5_dataset_name;
+    ar &lookup;
+    ar &gamma;
+  }
 };
 
 inline bool operator==(DiagramIndex const &first, DiagramIndex const &second) {

--- a/main/contract.cpp
+++ b/main/contract.cpp
@@ -8,6 +8,8 @@
 #include "global_data_build_IO_names.hpp"
 
 #include <omp.h>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
 
 #include <iostream>
 
@@ -36,6 +38,12 @@ int main(int ac, char *av[]) {
   GlobalData gd;
 
   read_parameters(gd, ac, av);
+
+  {
+    std::ofstream ofs("global_data.xml");
+    boost::archive::text_oarchive archive(ofs);
+    archive << gd;
+  }
 
   // initialization of OMP paralization
   Eigen::initParallel();

--- a/main/contract.cpp
+++ b/main/contract.cpp
@@ -8,8 +8,8 @@
 #include "global_data_build_IO_names.hpp"
 
 #include <omp.h>
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
 
 #include <iostream>
 
@@ -40,8 +40,8 @@ int main(int ac, char *av[]) {
   read_parameters(gd, ac, av);
 
   {
-    std::ofstream ofs("global_data.xml");
-    boost::archive::text_oarchive archive(ofs);
+    std::ofstream ofs("global_data.bin");
+    boost::archive::binary_oarchive archive(ofs);
     archive << gd;
   }
 

--- a/main/globaldata.cpp
+++ b/main/globaldata.cpp
@@ -1,0 +1,27 @@
+#include "Correlators.hpp"
+#include "git.hpp"
+#include "global_data.hpp"
+#include "global_data_build_IO_names.hpp"
+
+#include <omp.h>
+#include <boost/archive/binary_oarchive.hpp>
+
+#include <iostream>
+
+int main(int ac, char *av[]) {
+  std::cout << "This is sLapH-contractions:\n"
+            << "  git branch " << git_refspec << "\n"
+            << "  git revision " << git_sha1 << "\n"
+            << "  git state " << git_changes << "\n"
+            << "  compiled by " << git_user << " on " << git_host << "\n"
+            << "  running with up to " << omp_get_max_threads() << " OpenMP threads\n";
+
+  // reading global parameters from input file
+  GlobalData gd;
+
+  read_parameters(gd, ac, av);
+
+  std::ofstream ofs("global_data.bin", std::ios::binary);
+  boost::archive::binary_oarchive archive(ofs);
+  archive << gd;
+}

--- a/src/Correlators.cpp
+++ b/src/Correlators.cpp
@@ -11,12 +11,12 @@
 #include <omp.h>
 #include <Eigen/Dense>
 #include <boost/multi_array.hpp>
+#include <boost/serialization/vector.hpp>
 
 #include <complex>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <vector>
 
 int get_time_delta(BlockIterator const &slice_pair, int const Lt) {
   return abs((slice_pair.sink() - slice_pair.source() - Lt) % Lt);

--- a/src/GaugeField.cpp
+++ b/src/GaugeField.cpp
@@ -1,9 +1,9 @@
 #include "GaugeField.hpp"
 
 #include <boost/format.hpp>
+#include <boost/serialization/vector.hpp>
 
 #include <sstream>
-#include <vector>
 
 // member initializer is executed from left to right. Is used to set constant members
 GaugeField::GaugeField(const int _Lt,

--- a/tests/integration-L4/run-integration-test
+++ b/tests/integration-L4/run-integration-test
@@ -10,7 +10,7 @@ set -x
 # Delete the old files. In case they care not there, the glob is not matched and that file
 # cannot be found. Ignore that error/
 rm correlators/*.h5 || true
-rm global_data.bin
+rm global_data.bin || true
 
 "$1/globaldata" -i test_all.ini --start_config 1000 --end_config 1000
 

--- a/tests/integration-L4/run-integration-test-conjugated
+++ b/tests/integration-L4/run-integration-test-conjugated
@@ -10,7 +10,7 @@ set -x
 # Delete the old files. In case they care not there, the glob is not matched and that file
 # cannot be found. Ignore that error/
 rm correlators/*.h5 || true
-rm global_data.bin
+rm global_data.bin || true
 
 "$1/globaldata" -i test_conjugated.ini --start_config 1000 --end_config 1000
 

--- a/tests/integration-L4/run-integration-test-conjugated
+++ b/tests/integration-L4/run-integration-test-conjugated
@@ -12,8 +12,6 @@ set -x
 rm correlators/*.h5 || true
 rm global_data.bin
 
-"$1/globaldata" -i test_all.ini --start_config 1000 --end_config 1000
+"$1/globaldata" -i test_conjugated.ini --start_config 1000 --end_config 1000
 
 "$1/contract" global_data.bin
-
-./compare

--- a/tests/integration-L4/run-integration-test-neutral
+++ b/tests/integration-L4/run-integration-test-neutral
@@ -10,7 +10,7 @@ set -x
 # Delete the old files. In case they care not there, the glob is not matched and that file
 # cannot be found. Ignore that error/
 rm correlators/*.h5 || true
-rm global_data.bin
+rm global_data.bin || true
 
 "$1/globaldata" -i test_neutral.ini --start_config 1000 --end_config 1000
 

--- a/tests/integration-L4/run-integration-test-neutral
+++ b/tests/integration-L4/run-integration-test-neutral
@@ -12,8 +12,6 @@ set -x
 rm correlators/*.h5 || true
 rm global_data.bin
 
-"$1/globaldata" -i test_all.ini --start_config 1000 --end_config 1000
+"$1/globaldata" -i test_neutral.ini --start_config 1000 --end_config 1000
 
 "$1/contract" global_data.bin
-
-./compare

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -15,11 +15,14 @@ cd ..
 
 ubuntu_packages=(
     cmake
-    libhdf5-dev 
     hdf5-tools
+    libboost-filesystem-dev
+    libboost-program-options-dev
+    libboost-serialization-dev
+    libboost-system-dev
     libeigen3-dev
-    libboost-filesystem-dev libboost-system-dev libboost-program-options-dev
     libgtest-dev
+    libhdf5-dev 
 )
 sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse"
 #sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
This addresses Issue #85.

I use Boost serialization to write out the whole `GlobalData` object such that we can read it in later. If one chooses the text format, the file looks like this:

![screenshot_20190101_152456](https://user-images.githubusercontent.com/976924/50573757-1d78d300-0dda-11e9-8ab1-65c664df7f0b.png)

We will likely use the binary format going forward. For the little integration test we see a size difference of the formats:

| Format | Size / kiB |
| --- | ---: |
| Text | 144 |
| Binary | 231 |

I presume that we have a lot a single-digit integers in the code and therefore storing them as a digit and a space (2 bytes) is shorter than storing them as `int` (4 bytes) or even `ssize_t` (8 bytes). Loading times will likely be much better in binary, and these files do not have to be portable across architectures anyway.

The current state is that just a file `global_data.bin` is written out after populating that data structure. This is rather silly without offering to read it in. I would propose that we split this into two different programs, one does all the argument parsing and sets up `GlobalData` and then the `contract` executable just takes a single argument with the path to the serialized `GlobalData`.