### PR TITLE
Single time slice for benchmarking

### DIFF
--- a/include/Correlators.hpp
+++ b/include/Correlators.hpp
@@ -50,4 +50,5 @@ void contract(const ssize_t Lt,
               CorrelatorRequestsMap const &correlator_requests_map,
               DilutedFactorIndicesCollection const &quark_lookup,
               std::string const output_path,
-              std::string const output_filename);
+              std::string const output_filename,
+              int single_time_slice_combination);

--- a/include/global_data.hpp
+++ b/include/global_data.hpp
@@ -97,6 +97,8 @@ struct GlobalData {
   std::map<int, int> momentum_cutoff;
 
   HypPars hyp_parameters;
+
+  int single_time_slice_combination;
 };
 
 /**

--- a/main/contract.cpp
+++ b/main/contract.cpp
@@ -98,6 +98,7 @@ int main(int ac, char *av[]) {
              gd.correlator_requests_map,
              gd.quarkline_lookuptable,
              gd.path_output,
-             gd.filename_ending_correlators);
+             gd.filename_ending_correlators,
+             gd.single_time_slice_combination);
   }
 }

--- a/src/Correlators.cpp
+++ b/src/Correlators.cpp
@@ -49,7 +49,8 @@ void contract(const ssize_t Lt,
               CorrelatorRequestsMap const &correlator_requests_map,
               DilutedFactorIndicesCollection const &quark_lookup,
               std::string const output_path,
-              std::string const output_filename) {
+              std::string const output_filename,
+              int single_time_slice_combination) {
   std::vector<Diagram> diagrams;
 
   for (auto const &elem : correlator_requests_map) {
@@ -82,6 +83,10 @@ void contract(const ssize_t Lt,
 
 #pragma omp for schedule(dynamic)
     for (int b = 0; b < dilution_scheme.size(); ++b) {
+      if (single_time_slice_combination >= 0 && single_time_slice_combination != b) {
+        continue;
+      }
+
 #pragma omp critical(cout)
       {
         std::cout << "Thread " << std::setw(3) << omp_get_thread_num() << " of "

--- a/src/global_data.cpp
+++ b/src/global_data.cpp
@@ -81,6 +81,11 @@ void read_parameters(GlobalData &gd, int ac, char *av[]) {
                         po::value<std::string>(&output_file)->default_value("LapHs.out"),
                         "name of output file.");
 
+  generic.add_options()(
+      "single_time_slice_combination",
+      po::value<int>(&gd.single_time_slice_combination)->default_value(-1),
+      "Only compute this time slice combination (for benchmarking only)");
+
   // Declare a group of options that will be allowed both on command line and
   // in input file
   po::options_description config("Input file options");

--- a/src/global_data.cpp
+++ b/src/global_data.cpp
@@ -137,7 +137,7 @@ void read_parameters(GlobalData &gd, int ac, char *av[]) {
       "name_eigenvectors",
       po::value<std::string>(&gd.name_eigenvectors)->default_value("eigenvector"),
       "name of eigenvectors\nThe full name is internally created to:\n"
-      "\"name_of_eigenvectors.eigenvector\n. time slice.configuration\"");
+      "\"name_of_eigenvectors.configuration.time_slice\"");
   config.add_options()(
       "handling_vdaggerv",
       po::value<std::string>(&gd.handling_vdaggerv)->default_value("build"),


### PR DESCRIPTION
Running all contractions for benchmarking is a waste of time. Just running some of the diagrams does not give the correct result due to re-use across diagrams. Reducing momenta also skews the picture. We can, however, just compute one time slice combination instead of all of them. The code will then just run with a single thread in the contraction phase and we should get a profile much quicker.