### PR TITLE
Run with /usr/bin/time

### DIFF
--- a/job-script-generator/job_script_qbig_slurm.sh.j2
+++ b/job-script-generator/job_script_qbig_slurm.sh.j2
@@ -21,7 +21,7 @@ cd {{ rundir }}
 date
 
 {% for config_id in config_ids_for_one_job %}
-(../contract -i {{ config_path }} --start_config {{ config_id }} --end_config {{ config_id }} || exit 1) &
+(/usr/bin/time ../contract -i {{ config_path }} --start_config {{ config_id }} --end_config {{ config_id }} || exit 1) &
 {% endfor %}
 
 wait

--- a/job-script-generator/kill_runs.sh
+++ b/job-script-generator/kill_runs.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-
-for i in {609801..609854..1}; do
-
-  qdel $i.qbig
-
-done


### PR DESCRIPTION
I want to know the actually used memory, so I now let everything run with `/usr/bin/time`.